### PR TITLE
Added parallel array tests for parallel access

### DIFF
--- a/test/Reminiscence.Stresstests/Arrays/ArrayTests.cs
+++ b/test/Reminiscence.Stresstests/Arrays/ArrayTests.cs
@@ -24,6 +24,7 @@ using Reminiscence.Arrays;
 using Reminiscence.IO;
 using System;
 using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace Reminiscense.Stresstests.Arrays

--- a/test/Reminiscence.Stresstests/Arrays/ArrayTests.cs
+++ b/test/Reminiscence.Stresstests/Arrays/ArrayTests.cs
@@ -41,6 +41,7 @@ namespace Reminiscense.Stresstests.Arrays
             ArrayTests.TestWrite(ArrayProfile.NoCache);
             ArrayTests.TestRead(ArrayProfile.NoCache);
             ArrayTests.TestReadRandom(ArrayProfile.NoCache);
+            ArrayTests.TestParallelAccess();
             ArrayTests.TestHugeArray();
             ArrayTests.TestEnumerableArray();
         }
@@ -199,6 +200,21 @@ namespace Reminiscense.Stresstests.Arrays
             var array = new MemoryArray<long>(len);
             for (var i = 0L; i < len; i++) array[i] = i;
             foreach (var i in array) Assert.Equal(i, array[i]);
+        }
+
+        /// <summary>
+        /// Tests using an array with Parallel Access
+        /// </summary>
+        public static void TestParallelAccess()
+        {
+            var len = 1024;
+            var array = new MemoryArray<long>(len);
+            for (var i = 0L; i < len; i++) array[i] = i;
+            //Test accessing elements in parallel
+            System.Linq.ParallelEnumerable.ForAll(array.AsParallel(), i =>
+            {
+                Assert.Equal(i, array[i]);
+            });
         }
     }
 }

--- a/test/Reminiscence.Stresstests/Reminiscence.Stresstests.csproj
+++ b/test/Reminiscence.Stresstests/Reminiscence.Stresstests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/Reminiscence.Tests/Indexes/IndexTests.cs
+++ b/test/Reminiscence.Tests/Indexes/IndexTests.cs
@@ -501,15 +501,10 @@ namespace Reminiscence.Tests.Indexes
             ids.Add(new KeyValuePair<long, string>(index.Add("test"), "test"));
             ids.Add(new KeyValuePair<long, string>(index.Add("sentence"), "sentence"));
 
-            //Adding this allows the test to pass??
-            //foreach(var kvp in ids)
-            //{
-            //    Assert.AreEqual(index.Get(kvp.Key), kvp.Value);
-            //}
-
             ParallelEnumerable.ForAll(ids.AsParallel(), kvp =>
             {
-                Assert.AreEqual(index.Get(kvp.Key), kvp.Value);
+                string found = index.Get(kvp.Key);
+                Assert.AreEqual(found, kvp.Value);
             });
         }
 

--- a/test/Reminiscence.Tests/Indexes/IndexTests.cs
+++ b/test/Reminiscence.Tests/Indexes/IndexTests.cs
@@ -486,6 +486,34 @@ namespace Reminiscence.Tests.Indexes
         }
 
         /// <summary>
+        /// Tests <see cref="Index.Get(long)"/> in parallel
+        /// </summary>
+        [Test]
+        public void TestGetParallel()
+        {
+            var index = new Index<string>(new MemoryMapStream(), 32);
+
+            List<KeyValuePair<long, string>> ids = new List<KeyValuePair<long, string>>();
+
+            ids.Add(new KeyValuePair<long, string>(index.Add("this"), "this"));
+            ids.Add(new KeyValuePair<long, string>(index.Add("is"), "is"));
+            ids.Add(new KeyValuePair<long, string>(index.Add("another"), "another"));
+            ids.Add(new KeyValuePair<long, string>(index.Add("test"), "test"));
+            ids.Add(new KeyValuePair<long, string>(index.Add("sentence"), "sentence"));
+
+            //Adding this allows the test to pass??
+            //foreach(var kvp in ids)
+            //{
+            //    Assert.AreEqual(index.Get(kvp.Key), kvp.Value);
+            //}
+
+            ParallelEnumerable.ForAll(ids.AsParallel(), kvp =>
+            {
+                Assert.AreEqual(index.Get(kvp.Key), kvp.Value);
+            });
+        }
+
+        /// <summary>
         /// Tests enumeration.
         /// </summary>
         [Test]

--- a/test/Reminiscence.Tests/Reminiscence.Tests.csproj
+++ b/test/Reminiscence.Tests/Reminiscence.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>


### PR DESCRIPTION
`ArrayTests.TestParallelAccess()` is passing so the issue seems to be with Itinero and not in this library.