### PR TITLE
Native memory-mapped arrays: fix pointer offset.

### DIFF
--- a/src/Reminiscence/Arrays/NativeMemoryArrayHelper.cs
+++ b/src/Reminiscence/Arrays/NativeMemoryArrayHelper.cs
@@ -123,6 +123,28 @@ namespace Reminiscence.Arrays
                 head += toZero;
             }
         }
+
+#if NET45
+        // https://www.pinvoke.net/default.aspx/kernel32.getsysteminfo
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
+        internal struct SYSTEM_INFO
+        {
+            internal ushort wProcessorArchitecture;
+            internal ushort wReserved;
+            internal uint dwPageSize;
+            internal IntPtr lpMinimumApplicationAddress;
+            internal IntPtr lpMaximumApplicationAddress;
+            internal IntPtr dwActiveProcessorMask;
+            internal uint dwNumberOfProcessors;
+            internal uint dwProcessorType;
+            internal uint dwAllocationGranularity;
+            internal ushort wProcessorLevel;
+            internal ushort wProcessorRevision;
+        }
+
+        [System.Runtime.InteropServices.DllImport("kernel32", SetLastError = true)]
+        internal static extern void GetSystemInfo(out SYSTEM_INFO lpSystemInfo);
+#endif
     }
 }
 #endif

--- a/src/Reminiscence/Arrays/NativeMemoryMappedArray.cs
+++ b/src/Reminiscence/Arrays/NativeMemoryMappedArray.cs
@@ -202,7 +202,15 @@ namespace Reminiscence.Arrays
 
                 // warning: this ignores the offset / length that we used to create the accessor, so
                 // it's our responsibility to translate the offset and do bounds-checking.
-                this.HeadPointer = (T*)(this.acquiredPointer + finalByteOffset);
+#if NET45
+                // PointerOffset was added in .NET Framework 4.5.1.
+                // https://stackoverflow.com/a/42170762/1083771
+                NativeMemoryArrayHelper.GetSystemInfo(out var systemInfo);
+                long pointerOffset = finalByteOffset % systemInfo.dwAllocationGranularity;
+#else
+                long pointerOffset = memoryMappedViewAccessor.PointerOffset;
+#endif
+                this.HeadPointer = (T*)(this.acquiredPointer + pointerOffset);
                 this.LengthCore = finalLength;
             }
             catch

--- a/test/Reminiscence.Tests/Arrays/NativeMemoryMappedArrayTests.cs
+++ b/test/Reminiscence.Tests/Arrays/NativeMemoryMappedArrayTests.cs
@@ -195,7 +195,7 @@ namespace Reminiscence.Tests.Arrays
                 this.createdPaths.Add(path);
 
                 // write variable-length garbage before and after each important section.
-                file.Write(new byte[15]);
+                file.Write(new byte[70000]);
 
                 headByteOffset = file.Position;
                 file.Write(MemoryMarshal.AsBytes(headValues));


### PR DESCRIPTION
When trying to use some of the code from `NativeMemoryMappedArray<T>` in another project, I discovered an issue with the pointer offset: https://stackoverflow.com/a/42170762/1083771.

This fixes that issue and tweaks an existing test so that it would fail on Windows systems without the fix.